### PR TITLE
Some indentation and highlighting features

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,42 @@ Usage
 On .sml files you can execute *:make* to run your current buffer on SML, it also indent and shows
 SML sintaxis. See `:help sml-coursera.txt` for detailed information
 
+Indentation & highlighting features
+-----------------------------------
+
+There are some differences (features) from standard Vim 7.4 files.
+
+- No line wrapping (`textwidth = 0`).
+
+- Indent `case` as follows:
+
+        case x of
+          NONE => "none"
+        | SOME of str => str
+
+- Indent `handle` as follows:
+
+        call_smth_dangerous
+          handle Err1 => 41
+               | Err2 => 42
+
+- Indent functional pattern matching:
+
+        fun length [] = 0
+          | length _::xs = 1 + length xs
+
+- Indent `let` after `fun`:
+
+        fun double_sum (x, y) =
+          let val sum = x + y
+          in 2*sum end
+
+- Fix indentation of `if/then/else` when using `=`.
+
+- Fix highlighting of `=>`, `:=`.
+
+- Highlight record fields in type declaration, record creation and record patterns.
+
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/chilicuil/vim-sml-coursera/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 

--- a/syntax/sml.vim
+++ b/syntax/sml.vim
@@ -44,7 +44,7 @@ syn cluster  smlAllErrs contains=smlBraceErr,smlBrackErr,smlParenErr,smlCommentE
 
 syn cluster  smlAENoParen contains=smlBraceErr,smlBrackErr,smlCommentErr,smlEndErr,smlThenErr
 
-syn cluster  smlContained contains=smlTodo,smlPreDef,smlModParam,smlModParam1,smlPreMPRestr,smlMPRestr,smlMPRestr1,smlMPRestr2,smlMPRestr3,smlModRHS,smlFuncWith,smlFuncStruct,smlModTypeRestr,smlModTRWith,smlWith,smlWithRest,smlModType,smlFullMod
+syn cluster  smlContained contains=smlTodo,smlPreDef,smlModParam,smlModParam1,smlPreMPRestr,smlMPRestr,smlMPRestr1,smlMPRestr2,smlMPRestr3,smlModRHS,smlFuncWith,smlFuncStruct,smlModTypeRestr,smlModTRWith,smlWith,smlWithRest,smlModType,smlFullMod,smlRecordField
 
 
 " Enclosing delimiters
@@ -57,7 +57,6 @@ syn region   smlEncl transparent matchgroup=smlKeyword start="#\[" matchgroup=sm
 " Comments
 syn region   smlComment start="(\*" end="\*)" contains=smlComment,smlTodo
 syn keyword  smlTodo contained TODO FIXME XXX
-
 
 " let
 syn region   smlEnd matchgroup=smlKeyword start="\<let\>" matchgroup=smlKeyword end="\<end\>" contains=ALLBUT,@smlContained,smlEndErr
@@ -74,6 +73,8 @@ syn region   smlEnd matchgroup=smlKeyword start="\<begin\>" matchgroup=smlKeywor
 " if
 syn region   smlNone matchgroup=smlKeyword start="\<if\>" matchgroup=smlKeyword end="\<then\>" contains=ALLBUT,@smlContained,smlThenErr
 
+" record fields inside of record
+syn region   smlRecord transparent matchgroup=smlKeyword start="{" matchgroup=smlKeyword end="}"  contains=smlRecordField
 
 "" Modules
 
@@ -141,20 +142,22 @@ syn match    smlCharacter    +#"\\""\|#"."\|#"\\\d\d\d"+
 syn match    smlCharErr      +#"\\\d\d"\|#"\\\d"+
 syn region   smlString       start=+"+ skip=+\\\\\|\\"+ end=+"+
 
+syn match    smlKeyChar      "="
+syn match    smlKeyChar      "!"
+syn match    smlKeyChar      ";"
+syn match    smlKeyChar      "\*"
 syn match    smlFunDef       "=>"
 syn match    smlRefAssign    ":="
 syn match    smlTopStop      ";;"
 syn match    smlOperator     "\^"
 syn match    smlOperator     "::"
 syn match    smlAnyVar       "\<_\>"
-syn match    smlKeyChar      "!"
-syn match    smlKeyChar      ";"
-syn match    smlKeyChar      "\*"
-syn match    smlKeyChar      "="
 
 syn match    smlNumber	      "\<-\=\d\+\>"
 syn match    smlNumber	      "\<-\=0[x|X]\x\+\>"
 syn match    smlReal	      "\<-\=\d\+\.\d*\([eE][-+]\=\d\+\)\=[fl]\=\>"
+
+syn match    smlRecordField   "\<\w\+\>\(\s*[=:]\)\@=" contained
 
 " Synchronization
 syn sync minlines=20
@@ -212,6 +215,8 @@ if version >= 508 || !exists("did_sml_syntax_inits")
   HiLink smlAnyVar	 Keyword
   HiLink smlTopStop	 Keyword
   HiLink smlOperator	 Keyword
+
+  HiLink smlRecordField  Identifier
 
   HiLink smlBoolean	 Boolean
   HiLink smlCharacter	 Character


### PR DESCRIPTION
- No automatic line wrapping (textwidth = 0)
- Intend let if last line was fun
- Fix indent after functional pattern matching
- Fix indent of case/handle patterns
- Fix indent of then/else/end in insert mode and while =
- Fix highlight of =>, :=, ...
- Highlight record fields

There is also separate plugin only for indentation & syntax features: cypok/vim-sml.
